### PR TITLE
Bump version to 5.26.1

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # bricolage-mysql gem release note
 
+## version 5.26.1
+
+- [fix] mys3dump throws Exception when its internal queue is full.
+
 ## version 5.26.0
 
 - first release.

--- a/bricolage-mysql.gemspec
+++ b/bricolage-mysql.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'bricolage-mysql'
-  s.version = '5.26.0'
+  s.version = '5.26.1'
   s.summary = 'MySQL-related job classes for Bricolage batch framework'
   s.license = 'MIT'
 


### PR DESCRIPTION
-  [fix] mys3dump throws Exception when its internal queue is full

@aamine please