### PR TITLE
Bump version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,9 @@
 # bricolage-mysql gem release note
 
+## version 5.27.1
+
+- [fix] mys3dup throws java.lang.NoSuchMethodError on some JDK version.
+
 ## version 5.27.0
 
 - Export geometry type column as text by using AsText()

--- a/bricolage-mysql.gemspec
+++ b/bricolage-mysql.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.name = 'bricolage-mysql'
-  s.version = '5.27.0'
+  s.version = '5.27.1'
   s.summary = 'MySQL-related job classes for Bricolage batch framework'
   s.license = 'MIT'
 


### PR DESCRIPTION
- [fix] mys3dup throws java.lang.NoSuchMethodError on some JDK version.

FYI @aamine 