### PR TITLE
Force sqldump to use Bash

### DIFF
--- a/libexec/sqldump
+++ b/libexec/sqldump
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 binary="$0.$(uname -s)"
 if ! [[ -x $binary ]]


### PR DESCRIPTION
Some environments, for example recent Ubuntu, use Dash for `/bin/sh`, which does not have `[[` command.

@shimpeko @aamine Would you please review this patch?

Also, would you please invite me (<https://rubygems.org/profiles/nekketsuuu>) to bricolage-mysql gem owners to publish a new version of this gem? https://rubygems.org/gems/bricolage-mysql/